### PR TITLE
Filter moves for gen 1

### DIFF
--- a/src/components/PokemonDetails/PokemonDetails.js
+++ b/src/components/PokemonDetails/PokemonDetails.js
@@ -21,6 +21,21 @@ const PokemonDetails = ({ foundPokemon, getPokemonImage }) => {
       setError(error.message);
     }
   };
+
+  const filterMoves = () => {
+    const result = pokemonDetails.moves.map((move) => {
+      const version = move.version_group_details[0].version_group.name
+      const name = move.move.name.split("-").join(" ");
+
+      if (version === 'red-blue') {
+        return name;
+      }	
+    }).filter(move => {
+      return move !== undefined
+    }).sort((elementA, elementB) => elementA - elementB)
+    return result;
+  }  
+
   useEffect(() => {
     getPokemonDetails();
   }, [foundPokemon]);
@@ -31,7 +46,7 @@ const PokemonDetails = ({ foundPokemon, getPokemonImage }) => {
         <div className="pokemon-details-container">
           <h1 className="pokemon-details-id">{pokemonDetails.id}</h1>
 
-          <h1 className="pokemon-details-header">
+          <h1 className="pokemon-details-header capitalize">
             {pokemonDetails.name}{" "}
           </h1>
 
@@ -64,10 +79,10 @@ const PokemonDetails = ({ foundPokemon, getPokemonImage }) => {
           </article>
 
           <h2 className="moves-header">Moves</h2>
-          <article className="features-container moves-scroll">
-            {pokemonDetails.moves.map((move) => (
-              <p className="features" key={move.move.name}>
-                {move.move.name.split("-").join(" ")}
+          <article className="features-container move-scroll">
+            {filterMoves().map((move) => (
+              <p className="features" key={move}>
+                {move}
               </p>
             ))}
           </article>


### PR DESCRIPTION
# Description <img src="https://cdn190.picsart.com/232355564004212.png?type=webp&to=crop&r=256" alt="drawing" width="50"/>

* Make only the moves that existed during Gen 1 are shown


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

- [x] local host 3000
- [ ] console.log()
- [ ] dev tools
- [ ] cypress testing


# Checklist:

- [x] My code follows the style guidelines of this project/linted
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
